### PR TITLE
Add common ignores to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # .gitignore
 .env
+__pycache__/
+*.pyc
+node_modules/


### PR DESCRIPTION
## Summary
- avoid committing `__pycache__`, `*.pyc`, and `node_modules`

## Testing
- `python autoscaler/autoscaler.py --help` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_686c630e7670832585be0845ae0e8d07